### PR TITLE
orchestrator supports -version, generated by build file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 #
 set -e
 
-RELEASE_VERSION="1.4.551"
+RELEASE_VERSION="1.4.552"
 TOPDIR=/tmp/orchestrator-release
 export RELEASE_VERSION TOPDIR
 export GO15VENDOREXPERIMENT=1
@@ -75,7 +75,7 @@ function oinstall() {
   cd  $(dirname $0)
   gofmt -s -w  go/
   rsync -qa ./resources $builddir/orchestrator${prefix}/orchestrator/
-  rsync -qa ./conf/*.sample $builddir/orchestrator${prefix}/orchestrator/
+  rsync -qa ./conf/orchestrator-sample.* $builddir/orchestrator${prefix}/orchestrator/
   cp etc/init.d/orchestrator.bash $builddir/orchestrator/etc/init.d/orchestrator
   chmod +x $builddir/orchestrator/etc/init.d/orchestrator
 }
@@ -123,14 +123,15 @@ function build() {
   arch="$2"
   builddir="$3"
   prefix="$4"
-  gobuild="go build -o $builddir/orchestrator${prefix}/orchestrator/orchestrator go/cmd/orchestrator/main.go"
+  ldflags="-X main.AppVersion=${RELEASE_VERSION}"
+  gobuild="go build -ldflags \"$ldflags\" -o $builddir/orchestrator${prefix}/orchestrator/orchestrator go/cmd/orchestrator/main.go"
 
   case $os in
     'linux')
-      GOOS=$os GOARCH=$arch $gobuild
+      echo "GOOS=$os GOARCH=$arch $gobuild" | bash
     ;;
     'darwin')
-      GOOS=darwin GOARCH=amd64 $gobuild
+      echo "GOOS=darwin GOARCH=amd64 $gobuild" | bash
     ;;
   esac
 }

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -29,12 +29,14 @@ import (
 	"github.com/outbrain/orchestrator/go/inst"
 )
 
+var AppVersion string
+
 const prompt string = `
 orchestrator [-c command] [-i instance] [-d destination] [--verbose|--debug] [... cli ] | http
 
 Cheatsheet:
     Run orchestrator in HTTP mode:
-    
+
         orchestrator --debug http
 
     See all possible commands:
@@ -44,15 +46,15 @@ Cheatsheet:
     Usage for most commands:
         orchestrator -c <command> [-i <instance.fqdn>] [-d <destination.fqdn>] [--verbose|--debug]
 
-    -i (instance): 
+    -i (instance):
         instance on which to operate, in "hostname" or "hostname:port" format.
         Default port is 3306 (or DefaultInstancePort in config)
         For some commands this argument can be ommitted altogether, and the
         value is implicitly the local hostname.
-    -d (Destination) 
+    -d (Destination)
         destination instance (used when moving replicas around or when failing over)
     -s (Sibling/Subinstance/deStination) - synonym to "-d"
-        
+
     -c (command):
         Listed below are all available commands; all of which apply for CLI execution (ignored by HTTP mode).
         Different flags are required for different commands; see specific documentation per commmand.
@@ -75,15 +77,15 @@ Cheatsheet:
 
             orchestrator -c relocate -d destination.instance.that.becomes.its.master
                 -i not given, implicitly assumed local hostname
-                
+
             (this command was previously named "relocate-below")
 
         relocate-slaves
-            Relocates all or part of the slaves of a given instance under another (destination) instance. This is 
+            Relocates all or part of the slaves of a given instance under another (destination) instance. This is
             typically much faster than relocating slaves one by one.
             Orchestrator chooses the best course of action to relocation the slaves. It may choose a multi-step operations.
             Some slaves may succeed and some may fail the operation.
-            The instance (slaves' master) itself may be crashed or inaccessible. It is not contacted throughout the operation. 
+            The instance (slaves' master) itself may be crashed or inaccessible. It is not contacted throughout the operation.
             Examples:
 
             orchestrator -c relocate-slaves -i instance.whose.slaves.will.relocate -d instance.that.becomes.their.master
@@ -93,116 +95,116 @@ Cheatsheet:
 
     Topology refactoring using classic MySQL replication commands
         (ie STOP SLAVE; START SLAVE UNTIL; CHANGE MASTER TO; ...)
-        These commands require connected topology: slaves that are up and running; a lagging, stopped or 
-        failed slave will disable use of most these commands. At least one, and typically two or more slaves 
-        will be stopped for a short time during these operations. 
-        
+        These commands require connected topology: slaves that are up and running; a lagging, stopped or
+        failed slave will disable use of most these commands. At least one, and typically two or more slaves
+        will be stopped for a short time during these operations.
+
         move-up
             Move a slave one level up the topology; makes it replicate from its grandparent and become sibling of
             its parent. It is OK if the instance's master is not replicating. Examples:
-            
+
             orchestrator -c move-up -i slave.to.move.up.com:3306
 
             orchestrator -c move-up
                 -i not given, implicitly assumed local hostname
-            
+
         move-up-slaves
             Moves slaves of the given instance one level up the topology, making them siblings of given instance.
             This is a (faster) shortcut to executing move-up on all slaves of given instance.
             Examples:
-            
+
             orchestrator -c move-up-slaves -i slave.whose.subslaves.will.move.up.com[:3306]
-            
+
             orchestrator -c move-up-slaves -i slave.whose.subslaves.will.move.up.com[:3306] --pattern=regexp.filter
                 only apply to those instances that match given regex
 
         move-below
             Moves a slave beneath its sibling. Both slaves must be actively replicating from same master.
-            The sibling will become instance's master. No action taken when sibling cannot act as master 
+            The sibling will become instance's master. No action taken when sibling cannot act as master
             (e.g. has no binary logs, is of incompatible version, incompatible binlog format etc.)
             Example:
-            
+
             orchestrator -c move-below -i slave.to.move.com -d sibling.slave.under.which.to.move.com
 
             orchestrator -c move-below -d sibling.slave.under.which.to.move.com
                 -i not given, implicitly assumed local hostname
-                
+
         move-equivalent
             Moves a slave beneath another server, based on previously recorded "equivalence coordinates". Such coordinates
             are obtained whenever orchestrator issues a CHANGE MASTER TO. The "before" and "after" masters coordinates are
             persisted. In such cases where the newly relocated slave is unable to replicate (e.g. firewall issues) it is then
             easy to revert the relocation via "move-equivalent".
-            The command works if and only if orchestrator has an exact mapping between the slave's current replication coordinates 
+            The command works if and only if orchestrator has an exact mapping between the slave's current replication coordinates
             and some other coordinates.
             Example:
-            
-            orchestrator -c move-equivalent -i slave.to.revert.master.position.com -d master.to.move.to.com              
-            
+
+            orchestrator -c move-equivalent -i slave.to.revert.master.position.com -d master.to.move.to.com
+
         enslave-siblings
             Turn all siblings of a slave into its sub-slaves. No action taken for siblings that cannot become
             slaves of given instance (e.g. incompatible versions, binlog format etc.). This is a (faster) shortcut
             to executing move-below for all siblings of the given instance. Example:
-            
+
             orchestrator -c enslave-siblings -i slave.whose.siblings.will.move.below.com
-            
+
         enslave-master
             Turn an instance into a master of its own master; essentially switch the two. Slaves of each of the two
             involved instances are unaffected, and continue to replicate as they were.
             The instance's master must itself be a slave. It does not necessarily have to be actively replicating.
-            
+
             orchestrator -c enslave-master -i slave.that.will.switch.places.with.its.master.com
-            
+
         repoint
             Make the given instance replicate from another instance without changing the binglog coordinates. There
-            are little sanity checks to this and this is a risky operation. Use cases are: a rename of the master's 
+            are little sanity checks to this and this is a risky operation. Use cases are: a rename of the master's
             host, a corruption in relay-logs, move from beneath MaxScale & Binlog-server. Examples:
-            
+
             orchestrator -c repoint -i slave.to.operate.on.com -d new.master.com
-            
+
             orchestrator -c repoint -i slave.to.operate.on.com
-                The above will repoint the slave back to its existing master without change 
-            
+                The above will repoint the slave back to its existing master without change
+
             orchestrator -c repoint
                 -i not given, implicitly assumed local hostname
-            
+
         repoint-slaves
             Repoint all slaves of given instance to replicate back from the instance. This is a convenience method
             which implies a one-by-one "repoint" command on each slave.
-            
+
             orchestrator -c repoint-slaves -i instance.whose.slaves.will.be.repointed.com
-            
+
             orchestrator -c repoint-slaves
                 -i not given, implicitly assumed local hostname
-            
+
         make-co-master
             Create a master-master replication. Given instance is a slave which replicates directly from a master.
             The master is then turned to be a slave of the instance. The master is expected to not be a slave.
             The read_only property of the slve is unaffected by this operation. Examples:
-    
+
             orchestrator -c make-co-master -i slave.to.turn.into.co.master.com
-            
+
             orchestrator -c make-co-master
                 -i not given, implicitly assumed local hostname
-                
+
         get-candidate-slave
             Information command suggesting the most up-to-date slave of a given instance, which can be promoted
             as local master to its siblings. If replication is up and running, this command merely gives an
             estimate, since slaves advance and progress continuously in different pace. If all slaves of given
             instance have broken replication (e.g. because given instance is dead), then this command provides
             with a definitve candidate, which could act as a replace master. See also regroup-slaves. Example:
-            
+
             orchestrator -c get-candidate-slave -i instance.with.slaves.one.of.which.may.be.candidate.com
 
         regroup-slaves-bls
             Given an instance that has Binlog Servers for slaves, promote one such Binlog Server over its other
             Binlog Server siblings.
-            
+
             Example:
-            
+
             orchestrator -c regroup-slaves-bls -i instance.with.binlog.server.slaves.com
-            
+
             --debug is your friend.
-            
+
 
     Topology refactoring using GTID
         These operations only work if GTID (either Oracle or MariaDB variants) is enabled on your servers.
@@ -212,39 +214,39 @@ Cheatsheet:
             not enabled on the slave, or is not supported by the would-be master.
             You may try and move the slave under any other instance; there are no constraints on the family ties the
             two may have, though you should be careful as not to try and replicate from a descendant (making an
-            impossible loop). 
+            impossible loop).
             Examples:
-            
+
             orchestrator -c move-gtid -i slave.to.move.com -d instance.that.becomes.its.master
 
             orchestrator -c match -d destination.instance.that.becomes.its.master
                 -i not given, implicitly assumed local hostname
-            
+
         move-slaves-gtid
-            Moves all slaves of a given instance under another (destination) instance using GTID. This is a (faster) 
+            Moves all slaves of a given instance under another (destination) instance using GTID. This is a (faster)
             shortcut to moving each slave via "move-gtid".
             Orchestrator will only move those slaves configured with GTID (either Oracle or MariaDB variants) and under the
             condition the would-be master supports GTID.
             Examples:
-            
+
             orchestrator -c move-slaves-gtid -i instance.whose.slaves.will.relocate -d instance.that.becomes.their.master
-            
+
             orchestrator -c move-slaves-gtid -i instance.whose.slaves.will.relocate -d instance.that.becomes.their.master --pattern=regexp.filter
                 only apply to those instances that match given regex
-                
+
         regroup-slaves-gtid
             Given an instance (possibly a crashed one; it is never being accessed), pick one of its slave and make it
             local master of its siblings, using GTID. The rules are similar to those in the "regroup-slaves" command.
             Example:
-            
+
             orchestrator -c regroup-slaves-gtid -i instance.with.gtid.and.slaves.one.of.which.will.turn.local.master.if.possible
-            
+
             --debug is your friend.
-            
+
 
     Topology refactoring using Pseudo-GTID
         These operations require that the topology's master is periodically injected with pseudo-GTID,
-        and that the PseudoGTIDPattern configuration is setup accordingly. Also consider setting 
+        and that the PseudoGTIDPattern configuration is setup accordingly. Also consider setting
         DetectPseudoGTIDQuery.
         Operations via Pseudo-GTID are typically slower, since they involve scanning of binary/relay logs.
         They impose less constraints on topology locations and affect less servers. Only servers that
@@ -258,46 +260,46 @@ Cheatsheet:
             whether this is the case by the end; the operation is cancelled in the event this is not the case.
             No action taken when destination instance cannot act as master (e.g. has no binary logs, is of incompatible version, incompatible binlog format etc.)
             Examples:
-            
+
             orchestrator -c match -i slave.to.relocate.com -d instance.that.becomes.its.master
 
             orchestrator -c match -d destination.instance.that.becomes.its.master
                 -i not given, implicitly assumed local hostname
 
             (this command was previously named "match-below")
-            
+
         match-slaves
             Matches all slaves of a given instance under another (destination) instance. This is a (faster) shortcut
             to matching said slaves one by one under the destination instance. In fact, this bulk operation is highly
             optimized and can execute in orders of magnitue faster, depeding on the nu,ber of slaves involved and their
             respective position behind the instance (the more slaves, the more savings).
             The instance itself may be crashed or inaccessible. It is not contacted throughout the operation. Examples:
-            
+
             orchestrator -c match-slaves -i instance.whose.slaves.will.relocate -d instance.that.becomes.their.master
-            
+
             orchestrator -c match-slaves -i instance.whose.slaves.will.relocate -d instance.that.becomes.their.master --pattern=regexp.filter
                 only apply to those instances that match given regex
-            
+
             (this command was previously named "multi-match-slaves")
 
         match-up
             Transport the slave one level up the hierarchy, making it child of its grandparent. This is
-            similar in essence to move-up, only based on Pseudo-GTID. The master of the given instance 
+            similar in essence to move-up, only based on Pseudo-GTID. The master of the given instance
             does not need to be alive or connected (and could in fact be crashed). It is never contacted.
             Grandparent instance must be alive and accessible.
             Examples:
-            
+
             orchestrator -c match-up -i slave.to.match.up.com:3306
 
             orchestrator -c match-up
                 -i not given, implicitly assumed local hostname
-            
+
         match-up-slaves
             Matches slaves of the given instance one level up the topology, making them siblings of given instance.
             This is a (faster) shortcut to executing match-up on all slaves of given instance. The instance need
             not be alive / accessib;e / functional. It can be crashed.
             Example:
-            
+
             orchestrator -c match-up-slaves -i slave.whose.subslaves.will.match.up.com
 
             orchestrator -c match-up-slaves -i slave.whose.subslaves.will.match.up.com[:3306] --pattern=regexp.filter
@@ -307,34 +309,34 @@ Cheatsheet:
             Reconnect a slave onto its master, via PSeudo-GTID. The use case for this operation is a non-crash-safe
             replication configuration (e.g. MySQL 5.5) with sync_binlog=1 and log_slave_updates. This operation
             implies crash-safe-replication and makes it possible for the slave to reconnect. Example:
-            
+
             orchestrator -c rematch -i slave.to.rematch.under.its.master
-            
+
         regroup-slaves
             Given an instance (possibly a crashed one; it is never being accessed), pick one of its slave and make it
             local master of its siblings, using Pseudo-GTID. It is uncertain that there *is* a slave that will be able to
             become master to all its siblings. But if there is one, orchestrator will pick such one. There are many
-            constraints, most notably the replication positions of all slaves, whether they use log_slave_updates, and 
+            constraints, most notably the replication positions of all slaves, whether they use log_slave_updates, and
             otherwise version compatabilities etc.
             As many slaves that can be regrouped under promoted slves are operated on. The rest are untouched.
             This command is useful in the event of a crash. For example, in the event that a master dies, this operation
             can promote a candidate replacement and set up the remaining topology to correctly replicate from that
             replacement slave. Example:
-            
+
             orchestrator -c regroup-slaves -i instance.with.slaves.one.of.which.will.turn.local.master.if.possible
-            
+
             --debug is your friend.
 
     General replication commands
         These commands issue various statements that relate to replication.
-        
+
         enable-gtid
             If possible, enable GTID replication. This works on Oracle (>= 5.6, gtid-mode=1) and MariaDB (>= 10.0).
             Replication is stopped for a short duration so as to reconfigure as GTID. In case of error replication remains
             stopped. Example:
-            
+
             orchestrator -c enable-gtid -i slave.compatible.with.gtid.com
-            
+
         disable-gtid
             Assuming slave replicates via GTID, disable GTID replication and resume standard file:pos replication. Example:
 
@@ -345,121 +347,121 @@ Cheatsheet:
             This operation is only allowed on Oracle-GTID enabled servers that have no slaves.
             Is is used for cleaning up the GTID mess incurred by mistakenly issuing queries on the slave (even such
             queries as "FLUSH ENGINE LOGS" that happen to write to binary logs). Example:
-            
+
             orchestrator -c reset-master-gtid-remove-own-uuid -i slave.running.with.gtid.com
-                    
+
         stop-slave
             Issues a STOP SLAVE; command. Example:
 
             orchestrator -c stop-slave -i slave.to.be.stopped.com
-            
+
         start-slave
             Issues a START SLAVE; command. Example:
 
             orchestrator -c start-slave -i slave.to.be.started.com
-            
+
         restart-slave
             Issues STOP SLAVE + START SLAVE; Example:
 
             orchestrator -c restart-slave -i slave.to.be.started.com
-            
+
         skip-query
             On a failed replicating slave, skips a single query and attempts to resume replication.
             Only applies when the replication seems to be broken on SQL thread (e.g. on duplicate
             key error). Also works in GTID mode. Example:
 
             orchestrator -c skip-query -i slave.with.broken.sql.thread.com
-            
+
         reset-slave
             Issues a RESET SLAVE command. Destructive to replication. Example:
 
             orchestrator -c reset-slave -i slave.to.reset.com
-            
+
         detach-slave
             Stops replication and modifies binlog position into an impossible, yet reversible, value.
             This effectively means the replication becomes broken. See reattach-slave. Example:
-            
+
             orchestrator -c detach-slave -i slave.whose.replication.will.break.com
-            
+
             Issuing this on an already detached slave will do nothing.
-            
+
         reattach-slave
-            Undo a detach-slave operation. Reverses the binlog change into the original values, and 
+            Undo a detach-slave operation. Reverses the binlog change into the original values, and
             resumes replication. Example:
-            
+
             orchestrator -c reattach-slave -i detahced.slave.whose.replication.will.amend.com
 
             Issuing this on an attached (i.e. normal) slave will do nothing.
-    
+
         detach-slave-master-host
             Stops replication and modifies Master_Host into an impossible, yet reversible, value.
             This effectively means the replication becomes broken. See reattach-slave-master-host. Example:
-            
+
             orchestrator -c detach-slave-master-host -i slave.whose.replication.will.break.com
-            
+
             Issuing this on an already detached slave will do nothing.
-            
+
         reattach-slave-master-host
-            Undo a detach-slave-master-host operation. Reverses the hostname change into the original value, and 
+            Undo a detach-slave-master-host operation. Reverses the hostname change into the original value, and
             resumes replication. Example:
-            
+
             orchestrator -c reattach-slave-master-host -i detahced.slave.whose.replication.will.amend.com
 
             Issuing this on an attached (i.e. normal) slave will do nothing.
-    
+
     General instance commands
         Applying general instance configuration and state
 
         set-read-only
             Turn an instance read-only, via SET GLOBAL read_only := 1. Examples:
-            
+
             orchestrator -c set-read-only -i instance.to.turn.read.only.com
-            
+
             orchestrator -c set-read-only
                 -i not given, implicitly assumed local hostname
-            
+
         set-writeable
             Turn an instance writeable, via SET GLOBAL read_only := 0. Example:
-            
+
             orchestrator -c set-writeable -i instance.to.turn.writeable.com
-            
+
             orchestrator -c set-writeable
                 -i not given, implicitly assumed local hostname
 
     Binlog commands
         Commands that investigate/work on binary logs
-        
+
         flush-binary-logs
             Flush binary logs on an instance. Examples:
-            
+
             orchestrator -c flush-binary-logs -i instance.with.binary.logs.com
-            
+
             orchestrator -c flush-binary-logs -i instance.with.binary.logs.com --binlog=mysql-bin.002048
                 Flushes binary logs until reaching given number. Fails when current number is larger than input
-                        
+
         purge-binary-logs
             Purge binary logs on an instance. Examples:
-            
+
             orchestrator -c purge-binary-logs -i instance.with.binary.logs.com --binlog mysql-bin.002048
-            
+
                 Purges binary logs until given log
-            
+
         last-pseudo-gtid
             Information command; an authoritative way of detecting whether a Pseudo-GTID event exist for an instance,
             and if so, output the last Pseudo-GTID entry and its location. Example:
-            
+
             orchestrator -c last-pseudo-gtid -i instance.with.possible.pseudo-gtid.injection
 
         find-binlog-entry
             Get binlog file:pos of entry given by --pattern (exact full match, not a regular expression) in a given instance.
             This will search the instance's binary logs starting with most recent, and terminate as soon as an exact match is found.
-            The given input is not a regular expression. It must fully match the entry (not a substring). 
+            The given input is not a regular expression. It must fully match the entry (not a substring).
             This is most useful when looking for uniquely identifyable values, such as Pseudo-GTID. Example:
-            
+
             orchestrator -c find-binlog-entry -i instance.to.search.on.com --pattern "insert into my_data (my_column) values ('distinct_value_01234_56789')"
-            
+
                 Prints out the binlog file:pos where the entry is found, or errors if unfound.
-            
+
         correlate-binlog-pos
             Given an instance (-i) and binlog coordinates (--binlog=file:pos), find the correlated coordinates in another instance (-d).
             "Correlated coordinates" are those that present the same point-in-time of sequence of binary log events, untangling
@@ -469,70 +471,70 @@ Cheatsheet:
             You must provide a valid file:pos in the binlogs of the source instance (-i), and in response get the correlated
             coordinates in the binlogs of the destination instance (-d). This operation does not work on relay logs.
             Example:
-            
+
             orchestrator -c correlate-binlog-pos  -i instance.with.binary.log.com --binlog=mysql-bin.002366:14127 -d other.instance.with.binary.logs.com
-            
+
                 Prints out correlated coordinates, e.g.: "mysql-bin.002302:14220", or errors out.
-                                    
+
     Pool commands
         Orchestrator provides with getter/setter commands for handling pools. It does not on its own investigate pools,
         but merely accepts and provides association of an instance (host:port) and a pool (any_name).
-        
+
         submit-pool-instances
-            Submit a pool name with a list of instances in that pool. This removes any previous instances associated with 
+            Submit a pool name with a list of instances in that pool. This removes any previous instances associated with
             that pool. Expecting comma delimited list of instances
 
             orchestrator -c submit-pool-instances --pool name_of_pool -i pooled.instance1.com,pooled.instance2.com:3306,pooled.instance3.com
-        
+
         cluster-pool-instances
             List all pools and their associated instances. Output is in tab delimited format, and lists:
             cluster_name, cluster_alias, pool_name, pooled instance
             Example:
-            
+
             orchestrator -c cluster-pool-instances
 
     Information commands
         These commands provide/store information about topologies, replication connections, or otherwise orchstrator's
         "inventory".
-        
+
         find
             Find instances whose hostname matches given regex pattern. Example:
-            
+
             orchestrator -c find -pattern "backup.*us-east"
-            
+
         clusters
             List all clusters known to orchestrator. A cluster (aka topology, aka chain) is identified by its
             master (or one of its master if more than one exists). Example:
-            
+
             orchesrtator -c clusters
                 -i not given, implicitly assumed local hostname
-            
+
         topology
             Show an ascii-graph of a replication topology, given a member of that topology. Example:
-            
+
             orchestrator -c topology -i instance.belonging.to.a.topology.com
-            
+
             orchestrator -c topology
                 -i not given, implicitly assumed local hostname
-            
+
             Instance must be already known to orchestrator. Topology is generated by orchestrator's mapping
             and not from synchronuous investigation of the instances. The generated topology may include
             instances that are dead, or whose replication is broken.
-            
+
         which-instance
             Output the fully-qualified hostname:port representation of the given instance, or error if unknown
             to orchestrator. Examples:
-            
+
             orchestrator -c which-instance -i instance.to.check.com
-            
+
             orchestrator -c which-instance
                 -i not given, implicitly assumed local hostname
 
         which-cluster
             Output the name of the cluster an instance belongs to, or error if unknown to orchestrator. Examples:
-            
+
             orchestrator -c which-cluster -i instance.to.check.com
-            
+
             orchestrator -c which-cluster
                 -i not given, implicitly assumed local hostname
 
@@ -541,7 +543,7 @@ Cheatsheet:
             per instance, in hostname:port format. Examples:
 
             orchestrator -c which-cluster-instances -i instance.to.check.com
-            
+
             orchestrator -c which-cluster-instances
                 -i not given, implicitly assumed local hostname
 
@@ -555,7 +557,7 @@ Cheatsheet:
             where possible: intermediate masters, their slaves, 3rd level slaves, direct non-intermediate-master slaves.
 
             orchestrator -c which-cluster-osc-slaves -i instance.to.check.com
-            
+
             orchestrator -c which-cluster-osc-slaves
                 -i not given, implicitly assumed local hostname
 
@@ -564,25 +566,25 @@ Cheatsheet:
 
         which-master
             Output the fully-qualified hostname:port representation of a given instance's master. Examples:
-            
+
             orchestrator -c which-master -i a.known.slave.com
-            
+
             orchestrator -c which-master
                 -i not given, implicitly assumed local hostname
-                
+
         which-slaves
             Output the fully-qualified hostname:port list of slaves (one per line) of a given instance (or empty
             list if instance is not a master to anyone). Examples:
-             
+
             orchestrator -c which-slaves -i a.known.instance.com
-            
+
             orchestrator -c which-slaves
                 -i not given, implicitly assumed local hostname
-                
+
         get-cluster-heuristic-lag
             For a given cluster (indicated by an instance or alias), output a heuristic "representative" lag of that cluster.
             The output is obtained by examining the slaves that are member of "which-cluster-osc-slaves"-command, and
-            getting the maximum slave lag of those slaves. Recall that those slaves are a subset of the entire cluster, 
+            getting the maximum slave lag of those slaves. Recall that those slaves are a subset of the entire cluster,
             and that they are ebing polled periodically. Hence the output of this command is not necessarily up-to-date
             and does not represent all slaves in cluster. Examples:
 
@@ -596,143 +598,143 @@ Cheatsheet:
 
         instance-status
             Output short status on a given instance (name, replication status, noteable configuration). Example2:
-            
+
             orchestrator -c replication-status -i instance.to.investigate.com
-            
+
             orchestrator -c replication-status
                 -i not given, implicitly assumed local hostname
-                
+
         snapshot-topologies
-            Take a snapshot of existing topologies. This will record minimal replication topology data: the identity 
+            Take a snapshot of existing topologies. This will record minimal replication topology data: the identity
             of an instance, its master and its cluster.
             Taking a snapshot later allows for reviewing changes in topologies. One might wish to invoke this command
             on a daily basis, and later be able to solve questions like 'where was this instacne replicating from before
             we moved it?', 'which instances were replication from this instance a week ago?' etc. Example:
-            
+
             orchestrator -c snapshot-topologies
 
     Orchestrator instance management
-        These command dig into the way orchestrator manages instances and operations on instances           
-            
+        These command dig into the way orchestrator manages instances and operations on instances
+
         discover
-            Request that orchestrator cotacts given instance, reads its status, and upsert it into 
-            orchestrator's respository. Examples: 
-    
+            Request that orchestrator cotacts given instance, reads its status, and upsert it into
+            orchestrator's respository. Examples:
+
             orchestrator -c discover -i instance.to.discover.com:3306
 
             orchestrator -c discover -i cname.of.instance
 
             orchestrator -c discover
                 -i not given, implicitly assumed local hostname
-            
+
             Orchestrator will resolve CNAMEs and VIPs.
 
         forget
             Request that orchestrator removed given instance from its repository. If the instance is alive
             and connected through replication to otherwise known and live instances, orchestrator will
             re-discover it by nature of its discovery process. Instances are auto-removed via config's
-            UnseenAgentForgetHours. If you happen to know a machine is decommisioned, for example, it 
-            can be nice to remove it from the repository before it auto-expires. Example:  
+            UnseenAgentForgetHours. If you happen to know a machine is decommisioned, for example, it
+            can be nice to remove it from the repository before it auto-expires. Example:
 
             orchestrator -c forget -i instance.to.forget.com
-            
+
             Orchestrator will *not* resolve CNAMEs and VIPs for given instance.
-    
+
         begin-maintenance
             Request a maintenance lock on an instance. Topology changes require placing locks on the minimal set of
             affected instances, so as to avoid an incident of two uncoordinated operations on a smae instance (leading
             to possible chaos). Locks are placed in the backend database, and so multiple orchestrator instances are safe.
             Operations automatically acquire locks and release them. This command manually acquires a lock, and will
-            block other operations on the instance until lock is released. 
+            block other operations on the instance until lock is released.
             Note that orchestrator automatically assumes locks to be expired after MaintenanceExpireMinutes (in config).
             Examples:
-            
+
             orchestrator -c begin-maintenance -i instance.to.lock.com --duration=3h --reason="load testing; do not disturb"
                 accepted duration format: 10s, 30m, 24h, 3d, 4w
-            
+
             orchestrator -c begin-maintenance -i instance.to.lock.com --reason="load testing; do not disturb"
                 --duration not given; default to config's MaintenanceExpireMinutes
-            
+
         end-maintenance
             Remove maintenance lock; such lock may have been gained by an explicit begin-maintenance command implicitly
-            by a topology change. You should generally only remove locks you have placed manually; orchestrator will 
+            by a topology change. You should generally only remove locks you have placed manually; orchestrator will
             automatically expire locks after MaintenanceExpireMinutes (in config).
             Example:
-            
+
             orchestrator -c end-maintenance -i locked.instance.com
-    
+
         begin-downtime
             Mark an instance as downtimed. A downtimed instance is assumed to be taken care of, and recovery-analysis does
             not apply for such an instance. As result, no recommendation for recovery, and no automated-recovery are issued
             on a downtimed instance.
             Downtime is different than maintanence in that it places no lock (mainenance uses an exclusive lock on the instance).
             It is OK to downtime an instance that is already downtimed -- the new begin-downtime command will override whatever
-            previous downtime attributes there were on downtimes instance.  
+            previous downtime attributes there were on downtimes instance.
             Note that orchestrator automatically assumes downtime to be expired after MaintenanceExpireMinutes (in config).
             Examples:
-            
+
             orchestrator -c begin-downtime -i instance.to.downtime.com --duration=3h --reason="dba handling; do not do recovery"
                 accepted duration format: 10s, 30m, 24h, 3d, 4w
-            
-            orchestrator -c begin-downtime -i instance.to.lock.com --reason="dba handling; do not do recovery" 
+
+            orchestrator -c begin-downtime -i instance.to.lock.com --reason="dba handling; do not do recovery"
                 --duration not given; default to config's MaintenanceExpireMinutes
-            
+
         end-downtime
             Indicate an instance is no longer downtimed. Typically you should not need to use this since
             a downtime is always bounded by a duration and auto-expires. But you may use this to forcibly
             indicate the active downtime should be expired now.
             Example:
-            
+
             orchestrator -c end-downtime -i downtimed.instance.com
-    
+
     Crash recovery commands
-                        
+
         recover
             Do auto-recovery given a dead instance. Orchestrator chooses the best course of action.
             The given instance must be acknowledged as dead and have slaves, or else there's nothing to do.
-            See "replication-analysis" command. 
+            See "replication-analysis" command.
             Orchestrator executes external processes as configured by *Processes variables.
             --debug is your friend. Example:
-            
+
             orchestrator -c recover -i dead.instance.com --debug
-            
+
         recover-lite
-            Do auto-recovery given a dead instance. Orchestrator chooses the best course of action, exactly 
+            Do auto-recovery given a dead instance. Orchestrator chooses the best course of action, exactly
             as in "-c recover". Orchestratir will *not* execute external processes.
-            
+
             orchestrator -c recover-lite -i dead.instance.com --debug
 
         replication-analysis
-            Request an analysis of potential crash incidents in all known topologies. 
+            Request an analysis of potential crash incidents in all known topologies.
             Output format is not yet stabilized and may change in the future. Do not trust the output
             for automated parsing. Use web API instead, at this time. Example:
-            
+
             orchestrator -c replication-analysis
-            
+
         ack-cluster-recoveries
             Acknowledge recoveries for a given cluster; this unblocks pending future recoveries.
             Acknowledging a recovery requires a comment (supply via --reason). Acknowledgement clears the in-active-period
-            flag for affected recoveries, which in turn affects any blocking recoveries. 
+            flag for affected recoveries, which in turn affects any blocking recoveries.
             Multiple recoveries may be affected. Only unacknowledged recoveries will be affected.
-            Examples: 
-            
+            Examples:
+
             orchestrator -c ack-cluster-recoveries -i instance.in.a.cluster.com --reason="dba has taken taken necessary steps"
                  Cluster is indicated by any of its members. The recovery need not necessarily be on/to given instance.
-            
+
             orchestrator -c ack-cluster-recoveries -alias some_alias --reason="dba has taken taken necessary steps"
                  Cluster indicated by alias
-                 
+
         ack-instance-recoveries
             Acknowledge recoveries for a given instance; this unblocks pending future recoveries.
             Acknowledging a recovery requires a comment (supply via --reason). Acknowledgement clears the in-active-period
-            flag for affected recoveries, which in turn affects any blocking recoveries. 
+            flag for affected recoveries, which in turn affects any blocking recoveries.
             Multiple recoveries may be affected. Only unacknowledged recoveries will be affected.
-            Example: 
-            
+            Example:
+
             orchestrator -c ack-cluster-recoveries -i instance.that.failed.com --reason="dba has taken taken necessary steps"
 
     Instance meta commands
-    
+
         register-candidate
             Indicate that a specific instance is a preferred candidate for master promotion. Upon a dead master
             recovery, orchestrator will do its best to promote instances that are marked as candidates. However
@@ -740,22 +742,22 @@ Cheatsheet:
             etc. are limiting factors.
             You will want to mark an instance as a candidate when: it is replicating directly from the master, has
             binary logs and log_slave_updates is enabled, uses same binlog_format as its siblings, compatible version
-            as its siblings. If you're using DataCenterPattern & PhysicalEnvironmentPattern (see configuration), 
-            you would further wish to make sure you have a candidate in each data center. 
-            Orchestrator first promotes the best-possible slave, and only then replaces it with your candidate, 
+            as its siblings. If you're using DataCenterPattern & PhysicalEnvironmentPattern (see configuration),
+            you would further wish to make sure you have a candidate in each data center.
+            Orchestrator first promotes the best-possible slave, and only then replaces it with your candidate,
             and only if both in same datcenter and physical enviroment.
-            An instance needs to continuously be marked as candidate, so as to make sure orchestrator is not wasting 
+            An instance needs to continuously be marked as candidate, so as to make sure orchestrator is not wasting
             time with stale instances. Orchestrator periodically clears candidate-registration for instances that have
             not been registeres for over CandidateInstanceExpireMinutes (see config).
             Example:
-            
+
             orchestrator -c register-candidate -i candidate.instance.com
-            
+
             orchestrator -c register-candidate
                 -i not given, implicitly assumed local hostname
-            
+
         register-hostname-unresolve
-            Assigns the given instance a virtual (aka "unresolved") name. When moving slaves under an instance with assigned 
+            Assigns the given instance a virtual (aka "unresolved") name. When moving slaves under an instance with assigned
             "unresolve" name, orchestrator issues a CHANGE MASTER TO MASTER_HOST='<the unresovled name instead of the fqdn>' ...
             This is useful in cases where your master is behind virtual IP (e.g. active/passive masters with shared storage or DRBD,
             e.g. binlog servers sharing common VIP).
@@ -763,45 +765,45 @@ Cheatsheet:
             same location, and orchestrator will swap the fqdn of their master with the unresolved name.
             Such registration must be periodic. Orchestrator automatically expires such registration after ExpiryHostnameResolvesMinutes.
             Example:
-                        
-            orchestrator -c register-hostname-unresolve -i instance.fqdn.com --hostname=virtual.name.com                   
-            
+
+            orchestrator -c register-hostname-unresolve -i instance.fqdn.com --hostname=virtual.name.com
+
         deregister-hostname-unresolve
             Explicitly deregister/dosassociate a hostname with an "unresolved" name. Orchestrator merely remvoes the association, but does
             not touch any slave at this point. A "repoint" command can be useful right after calling this command to change slave's master host
-            name (assumed to be an "unresolved" name, such as a VIP) with the real fqdn of the master host.   
+            name (assumed to be an "unresolved" name, such as a VIP) with the real fqdn of the master host.
             Example:
-                        
-            orchestrator -c deregister-hostname-unresolve -i instance.fqdn.com                 
-            
+
+            orchestrator -c deregister-hostname-unresolve -i instance.fqdn.com
+
     Misc commands
-    
+
         continuous
             Enter continuous mode, and actively poll for instances, diagnose problems, do maintenance etc.
             This type of work is typically done in HTTP mode. However nothing prevents orchestrator from
             doing it in command line. Invoking with "continuous" will run indefinitely. Example:
-            
-            orchestrator -c continuous  
-            
+
+            orchestrator -c continuous
+
         reset-hostname-resolve-cache
             Clear the hostname resolve cache; it will be refilled by following host discoveries
-            
+
             orchestrator -c reset-hostname-resolve-cache
-            
+
         resolve
             Utility command to resolve a CNAME and return resolved hostname name. Example:
-            
+
             orchestrator -c resolve -i cname.to.resolve
-            
+
         reset-internal-db-deployment
             Clear internal db deployment history, use if somehow corrupted internal deployment history.
-            When configured with '"SmartOrchestratorDatabaseUpdate": true', Orchestrator does housekeeping for its 
+            When configured with '"SmartOrchestratorDatabaseUpdate": true', Orchestrator does housekeeping for its
             own database schema, and verifies proposed deployment vs deployment history.
-            In case of contradiction between the two orchestrator bails out. Such a contradiction should not occur, and may 
-            signify an inconsistency in the orchestrator code itself.  
+            In case of contradiction between the two orchestrator bails out. Such a contradiction should not occur, and may
+            signify an inconsistency in the orchestrator code itself.
             By resetting history orchestrator redeploys its schema (without causing data loss) and accepts the new instructions
             as the de-factor deployment rule.
-            
+
     `
 
 // main is the application's entry point. It will either spawn a CLI or HTTP itnerfaces.
@@ -830,6 +832,7 @@ func main() {
 	config.RuntimeCLIFlags.Noop = flag.Bool("noop", false, "Dry run; do not perform destructing operations")
 	config.RuntimeCLIFlags.BinlogFile = flag.String("binlog", "", "Binary log file name")
 	config.RuntimeCLIFlags.GrabElection = flag.Bool("grab-election", false, "Grab leadership (only applies to continuous mode)")
+	config.RuntimeCLIFlags.Version = flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
 	if *destination != "" && *sibling != "" {
@@ -850,6 +853,11 @@ func main() {
 		log.SetPrintStackTrace(*stack)
 	}
 	log.Info("starting")
+
+	if *config.RuntimeCLIFlags.Version {
+		fmt.Println(AppVersion)
+		return
+	}
 
 	runtime.GOMAXPROCS(math.MinInt(4, runtime.NumCPU()))
 
@@ -888,7 +896,7 @@ func main() {
 	case flag.Arg(0) == "http":
 		app.Http(*discovery)
 	default:
-		fmt.Fprintln(os.Stderr, `Usage: 
+		fmt.Fprintln(os.Stderr, `Usage:
   orchestrator --options... [cli|http]
 See complete list of commands:
   orchestrator -c help

--- a/go/config/cli_flags.go
+++ b/go/config/cli_flags.go
@@ -24,6 +24,7 @@ type CLIFlags struct {
 	BinlogFile         *string
 	Databaseless       *bool
 	GrabElection       *bool
+	Version            *bool
 }
 
 var RuntimeCLIFlags CLIFlags


### PR DESCRIPTION
This utilizes ldflags.

Build file updates with updated version and support for ldflags
See original issue: https://github.com/outbrain/orchestrator/issues/140