### PR TITLE
added cli command: which-cluster-master

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -860,6 +860,18 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			clusterName := getClusterName(clusterAlias, instanceKey)
 			fmt.Println(clusterName)
 		}
+	case registerCliCommand("which-cluster-master", "Information", `Output the name of the master in a given cluster`):
+		{
+			clusterName := getClusterName(clusterAlias, instanceKey)
+			masters, err := inst.ReadClusterWriteableMaster(clusterName)
+			if err != nil {
+				log.Fatale(err)
+			}
+			if len(masters) == 0 {
+				log.Fatalf("No writeable masters found for cluster %+v", clusterName)
+			}
+			fmt.Println(masters[0].Key.DisplayString())
+		}
 	case registerCliCommand("which-cluster-instances", "Information", `Output the list of instances participating in same cluster as given instance`):
 		{
 			clusterName := getClusterName(clusterAlias, instanceKey)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -684,6 +684,19 @@ func ReadClusterInstances(clusterName string) ([](*Instance), error) {
 	return readInstancesByCondition(condition, sqlutils.Args(clusterName), "")
 }
 
+// ReadClusterWriteableMaster returns the/a writeable master of this cluster
+// Typically, the cluster name indicates the master of the cluster. However, in circular
+// master-master replication one master can assume the name of the cluster, and it is
+// not guaranteed that it is the writeable one.
+func ReadClusterWriteableMaster(clusterName string) ([](*Instance), error) {
+	condition := `
+		cluster_name = ?
+		and read_only = 0
+		and (replication_depth = 0 or is_co_master)
+	`
+	return readInstancesByCondition(condition, sqlutils.Args(clusterName), "replication_depth asc")
+}
+
 // ReadSlaveInstances reads slaves of a given master
 func ReadSlaveInstances(masterKey *InstanceKey) ([](*Instance), error) {
 	condition := `


### PR DESCRIPTION
added cli command: which-cluster-master
instance_dao:
- supports ReadClusterWriteableMaster()
cluster_alias_dao: ReadClusterByAlias() supports returning a cluster by its own name (even if not aliased by that name)