### PR TITLE
fixed infinite binlog loop on relay logs

### DIFF
--- a/go/inst/instance_binlog.go
+++ b/go/inst/instance_binlog.go
@@ -18,10 +18,11 @@ package inst
 
 import (
 	"errors"
-	"github.com/outbrain/golib/log"
-	"github.com/outbrain/orchestrator/go/config"
 	"regexp"
 	"strings"
+
+	"github.com/outbrain/golib/log"
+	"github.com/outbrain/orchestrator/go/config"
 )
 
 // Event entries may contains table IDs (can be different for same tables on different servers)
@@ -138,7 +139,11 @@ func (this *BinlogEventCursor) nextEvent(numEmptyEventsEvents int) (*BinlogEvent
 
 // NextRealEvent returns the next event from binlog that is not meta/control event (these are start-of-binary-log,
 // rotate-binary-log etc.)
-func (this *BinlogEventCursor) nextRealEvent() (*BinlogEvent, error) {
+func (this *BinlogEventCursor) nextRealEvent(recursionLevel int) (*BinlogEvent, error) {
+	if recursionLevel > maxEmptyEventsEvents {
+		log.Debugf("End of real events")
+		return nil, nil
+	}
 	event, err := this.nextEvent(0)
 	if err != nil {
 		return event, err
@@ -150,12 +155,12 @@ func (this *BinlogEventCursor) nextRealEvent() (*BinlogEvent, error) {
 	if _, found := skippedEventTypes[event.EventType]; found {
 		// Recursion will not be deep here. A few entries (end-of-binlog followed by start-of-bin-log) are possible,
 		// but we really don't expect a huge sequence of those.
-		return this.nextRealEvent()
+		return this.nextRealEvent(recursionLevel + 1)
 	}
 	for _, skipSubstring := range config.Config.SkipBinlogEventsContaining {
 		if strings.Index(event.Info, skipSubstring) >= 0 {
 			// Recursion might go deeper here.
-			return this.nextRealEvent()
+			return this.nextRealEvent(recursionLevel + 1)
 		}
 	}
 	event.NormalizeInfo()

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -420,7 +420,7 @@ func GetNextBinlogCoordinatesToMatch(instance *Instance, instanceCoordinates Bin
 		var otherEventCoordinates BinlogCoordinates
 		{
 			// Extract next binlog/relaylog entry from instance:
-			event, err := instanceCursor.nextRealEvent()
+			event, err := instanceCursor.nextRealEvent(0)
 			if err != nil {
 				return nil, 0, log.Errore(err)
 			}
@@ -488,7 +488,7 @@ func GetNextBinlogCoordinatesToMatch(instance *Instance, instanceCoordinates Bin
 		}
 		{
 			// Extract next binlog/relaylog entry from otherInstance (intended master):
-			event, err := otherCursor.nextRealEvent()
+			event, err := otherCursor.nextRealEvent(0)
 			if err != nil {
 				return nil, 0, log.Errore(err)
 			}


### PR DESCRIPTION
This would happen when the last relay log had no "Real" events: just the begin & rotate events; in this case orchestrator would keep on re-reading same file again and again.
There's now a safety latch to avoid infinite recursion.

It is not the prettiest solution, granted, but it works; and I suspect the more correct solution would make the code more complex.